### PR TITLE
Set explicit workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
         run: ls build/assets/temml-*/Temml-NotoSans.css && ls build/assets/temml-*/NotoSansMath-Regular.ttf
   build_windows:
     runs-on: windows-latest
+    permissions:
+      contents: read
     needs: build
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
   build_slower:
     needs: build
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/tats-u/docusaurus-plugin-copy-temml-assets/security/code-scanning/1](https://github.com/tats-u/docusaurus-plugin-copy-temml-assets/security/code-scanning/1)

To fix the issue, we will add an explicit `permissions` block to the `build_slower` job. This block will specify the minimal permissions required for the job to function correctly. Based on the job's steps, it only needs `contents: read` to access the repository's contents. This change ensures that the job does not inherit unnecessary permissions from the repository or organization.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
